### PR TITLE
Setup estructura base

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Token de acceso a la API de ClickUp
+CLICKUP_TOKEN=tu_token_aqui
+
+# Puerto opcional para el servidor
+# PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reportes ClickUp
 
-API sencilla para obtener tareas desde ClickUp.
+API sencilla para obtener tareas desde ClickUp lista para desplegar en Heroku.
 
 ## Uso
 
@@ -8,7 +8,7 @@ API sencilla para obtener tareas desde ClickUp.
    ```bash
    npm install
    ```
-2. Crea un archivo `.env` con tu `CLICKUP_TOKEN`.
+2. Copia `.env.example` a `.env` y coloca tu `CLICKUP_TOKEN`.
 3. Inicia el servidor:
    ```bash
    npm start

--- a/index.js
+++ b/index.js
@@ -1,24 +1,12 @@
 const express = require('express');
-const fetch = require('node-fetch');
+const { obtenerTareas } = require('./utils/clickup'); // Funciones para la API de ClickUp
 require('dotenv').config();
 
 const app = express();
+// Heroku proporciona el puerto en la variable PORT
 const PORT = process.env.PORT || 3000;
-const CLICKUP_API_BASE = 'https://api.clickup.com/api/v2';
 
-/**
- * Obtiene las tareas de un equipo en ClickUp.
- * @param {string} teamId - ID del equipo en ClickUp.
- * @param {string} token - Token de autenticaci\xC3\xB3n para la API.
- * @returns {Promise<object>} Respuesta JSON de ClickUp con la lista de tareas.
- */
-async function obtenerTareas(teamId, token) {
-  const url = `${CLICKUP_API_BASE}/team/${teamId}/task`;
-  const resp = await fetch(url, { headers: { Authorization: token } });
-  return resp.json();
-}
-
-// Endpoint de prueba
+// Endpoint base para verificar funcionamiento
 app.get('/', (req, res) => {
   res.send('API de reportes ClickUp funcionando');
 });

--- a/utils/clickup.js
+++ b/utils/clickup.js
@@ -1,0 +1,32 @@
+const fetch = require('node-fetch');
+
+const CLICKUP_API_BASE = 'https://api.clickup.com/api/v2';
+
+/**
+ * Realiza una solicitud a la API de ClickUp.
+ * @param {string} endpoint - Endpoint a consultar.
+ * @param {string} token - Token de autenticación para la API.
+ * @returns {Promise<object>} Respuesta JSON de la API.
+ */
+async function callClickUp(endpoint, token) {
+  const url = `${CLICKUP_API_BASE}${endpoint}`;
+  const resp = await fetch(url, { headers: { Authorization: token } });
+  if (!resp.ok) {
+    throw new Error(`Error ${resp.status}`);
+  }
+  return resp.json();
+}
+
+/**
+ * Obtiene las tareas de un equipo en ClickUp.
+ * @param {string} teamId - ID del equipo.
+ * @param {string} token - Token de autenticación.
+ * @returns {Promise<object>} Tareas obtenidas.
+ */
+function obtenerTareas(teamId, token) {
+  return callClickUp(`/team/${teamId}/task`, token);
+}
+
+module.exports = {
+  obtenerTareas,
+};


### PR DESCRIPTION
## Summary
- modularizar lógica de ClickUp en `utils/clickup.js`
- leer token desde `.env` usando un ejemplo en `.env.example`
- mejorar guía de uso en README
- ajustar `index.js` para utilizar el nuevo módulo

## Testing
- `npm install`
- `node index.js` (servidor inicia correctamente)

------
https://chatgpt.com/codex/tasks/task_e_684c418bc4d88328a2a0598f087041a5