### PR TITLE
Add endpoint alias for /api_tareas.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ API sencilla para obtener tareas desde ClickUp lista para desplegar en Heroku.
    ```bash
    npm start
    ```
+
+Una vez iniciado el servidor puedes consultar las tareas con los siguientes
+endpoints equivalentes:
+
+```
+GET /api_tareas
+GET /api_tareas.php
+```
+
+Recuerda proporcionar el parámetro `team_id` y definir tu `CLICKUP_TOKEN` en el
+archivo `.env`.

--- a/index.js
+++ b/index.js
@@ -6,13 +6,16 @@ const app = express();
 // Heroku proporciona el puerto en la variable PORT
 const PORT = process.env.PORT || 3000;
 
+// Endpoints disponibles para la consulta de tareas
+const API_TAREAS_ENDPOINTS = ['/api_tareas', '/api_tareas.php'];
+
 // Endpoint base para verificar funcionamiento
 app.get('/', (req, res) => {
   res.send('API de reportes ClickUp funcionando');
 });
 
 // Devuelve las tareas de un equipo especificado
-app.get('/api_tareas', async (req, res) => {
+app.get(API_TAREAS_ENDPOINTS, async (req, res) => {
   const { team_id: teamId } = req.query;
   const token = process.env.CLICKUP_TOKEN;
 


### PR DESCRIPTION
## Summary
- support `/api_tareas.php` as an alias for `/api_tareas`
- document new endpoint options in README

## Testing
- `npm install`
- `node index.js` *(fails: missing express before install)*
- `node index.js` after install and curl endpoints

------
https://chatgpt.com/codex/tasks/task_e_684c477114f48328a0cb108464d8936e