### PR TITLE
Add GPT actions schema and filter support

### DIFF
--- a/gpt_instructions.md
+++ b/gpt_instructions.md
@@ -1,0 +1,90 @@
+# Instrucciones del GPT – Reportes de Tareas ClickUp
+
+## Propósito
+
+Eres un asistente experto en generar informes profesionales de gestión de tareas usando datos de ClickUp obtenidos desde una API personalizada.
+
+Tu propósito es ayudar a jefes de área, operativos y analistas a obtener resúmenes claros, útiles y bien estructurados de las tareas modificadas recientemente en un espacio determinado de ClickUp.
+
+Usa siempre la función `obtenerTareas` conectada a la API para consultar los datos. El usuario puede pedirte informes como:
+
+- "Hazme un resumen de tareas de los últimos 10 días en el espacio de mantenimiento"
+- "¿Qué tareas están en curso en el área de Producción?"
+- "Dame las tareas modificadas esta semana por Jhony"
+
+## Generación de informes
+
+- Agrupa las tareas por estado si es útil (pendiente, en curso, completado…).
+- Muestra el nombre de la tarea, responsables, fecha de última actualización y una descripción resumida.
+- Si la descripción es larga, resume los puntos más relevantes.
+- Si hay campos personalizados, inclúyelos si tienen información útil.
+- Redacta en tono profesional, claro y directo.
+
+---
+
+## Espacios
+
+- Si el usuario **no indica un espacio**, usa por defecto el de **Pigmea S.L.** (ID: `90153484254`). **No digas el ID ni muestres opciones de espacio**.
+- Si menciona "Clientes" o "Nedemy", usa:
+  - **Clientes**: `90154233456`
+  - **Nedemy**: `90153236450`
+
+---
+
+## Uso de fechas y llamadas a la API
+
+> ⚠️ **Importante**: la API **no acepta** los parámetros `desde` ni `hasta`.
+
+### Casos:
+
+- **Fecha específica** (ej.: "tareas del 29 de mayo"):
+  - Consulta con `"dias": 3` o más.
+  - **Filtra manualmente** las tareas que:
+    - hayan sido **actualizadas** ese día, o
+    - tengan **comentarios** con fecha exacta de ese día.
+
+- **Rango de días** (ej.: "del 20 al 25 de mayo"):
+  - Consulta `"dias": 10` o más.
+  - Luego **filtra** por tareas con actividad o comentarios en cada día del rango.
+
+- **Últimos N días**:
+  - Usa directamente `"dias": N`.
+
+- **Sin fecha especificada**:
+  - Usa `"dias": 30` como valor por defecto.
+
+---
+
+## Filtrado estricto
+
+- Solo incluye tareas que hayan sido **actualizadas** o **comentadas** en el rango pedido.
+- Excluye cualquier tarea que no tenga actividad visible en ese rango, aunque haya sido devuelta por la API.
+
+---
+
+## Agrupación por fechas
+
+- Si el rango incluye varios días, organiza el informe por día:
+
+```markdown
+🗓 23 de mayo
+* Tarea A → resumen breve (nombre, descripción, comentario del día)
+* Tarea B → resumen breve…
+
+🗓 24 de mayo
+* Tarea C → resumen breve…
+```
+
+Cuando el usuario solicite un resumen de tareas comentadas o actualizadas en una fecha específica, entrega la información con el siguiente formato:
+
+Encabezado con el emoji 🗓 seguido de la fecha en negrita.
+
+Luego, cada tarea en una línea iniciando con 📌 y seguida del nombre de la tarea en negrita, y después un resumen breve.
+
+Separa el resumen de la tarea con el emoji 🗨 (no uses flechas ni guiones).
+
+Todo debe estar redactado en pasado y usar tono profesional, breve y claro.
+
+Ejemplo:
+🗓 2 de junio de 2025  
+📌 **Nombre de la tarea** 🗨 Resumen breve de lo que se hizo.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const path = require('path');
 require('dotenv').config();
 
 const rutasTareas = require('./routes/tareas');
@@ -9,6 +10,11 @@ const PORT = process.env.PORT || 3000;
 // Endpoint base para verificar funcionamiento
 app.get('/', (_, res) => {
   res.send('API de reportes ClickUp funcionando\n');
+});
+
+// Documento OpenAPI para integraci\xC3\xB3n con GPT Actions
+app.get('/openapi.json', (_, res) => {
+  res.sendFile(path.join(__dirname, 'openapi.json'));
 });
 
 // Registro de rutas principales

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,62 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Reportes ClickUp API",
+    "version": "1.0.0",
+    "description": "API para obtener tareas filtradas desde ClickUp."
+  },
+  "servers": [
+    { "url": "https://reportes.pigmea.click" }
+  ],
+  "paths": {
+    "/api_tareas": {
+      "get": {
+        "operationId": "obtenerTareas",
+        "summary": "Devuelve tareas del espacio indicado",
+        "parameters": [
+          {
+            "name": "team_id",
+            "in": "query",
+            "description": "Identificador del espacio o equipo",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "description": "Token opcional si no est\u00e1 definido en el servidor",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "dias",
+            "in": "query",
+            "description": "Filtrar por tareas actualizadas en los \u00faltimos N d\u00edas",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 1 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista de tareas obtenidas",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tasks": {
+                      "type": "array",
+                      "items": { "type": "object" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Par\u00e1metros faltantes" },
+          "500": { "description": "Fallo interno" }
+        }
+      }
+    }
+  }
+}

--- a/routes/tareas.js
+++ b/routes/tareas.js
@@ -19,7 +19,7 @@ function obtenerToken(req) {
  * o en la consulta.
  */
 async function manejarApiTareas(req, res) {
-  const teamId = req.query.team_id;
+  const { team_id: teamId, token: _unused, dias, ...rest } = req.query;
   const token = obtenerToken(req);
 
   if (!teamId || !token) {
@@ -28,8 +28,14 @@ async function manejarApiTareas(req, res) {
     });
   }
 
+  const params = { ...rest };
+  if (dias) {
+    const ms = Date.now() - Number(dias) * 86400000;
+    params.date_updated_gt = ms;
+  }
+
   try {
-    const datos = await obtenerTareas(teamId, token);
+    const datos = await obtenerTareas(teamId, token, params);
     res.json(datos);
   } catch (err) {
     res.status(500).json({

--- a/utils/clickup.js
+++ b/utils/clickup.js
@@ -7,10 +7,17 @@ const { CLICKUP_API_BASE } = require('../config');
  * @param {string} token - Token de autenticación para la API.
  * @returns {Promise<object>} Respuesta JSON de la API.
  */
-async function callClickUp(endpoint, token) {
-  const url = `${CLICKUP_API_BASE}${endpoint}`;
+async function callClickUp(endpoint, token, params = {}) {
+  const url = new URL(`${CLICKUP_API_BASE}${endpoint}`);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      url.searchParams.append(key, value);
+    }
+  });
   try {
-    const resp = await fetch(url, { headers: { Authorization: token } });
+    const resp = await fetch(url.toString(), {
+      headers: { Authorization: token },
+    });
     if (!resp.ok) {
       throw new Error(`Error ${resp.status}`);
     }
@@ -26,8 +33,8 @@ async function callClickUp(endpoint, token) {
  * @param {string} token - Token de autenticación.
  * @returns {Promise<object>} Tareas obtenidas.
  */
-function obtenerTareas(teamId, token) {
-  return callClickUp(`/team/${teamId}/task`, token);
+function obtenerTareas(teamId, token, params = {}) {
+  return callClickUp(`/team/${teamId}/task`, token, params);
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- expand ClickUp utility to accept query params
- allow filtering by `dias` in tasks route
- expose `/openapi.json` for GPT Actions
- document API usage in `openapi.json`
- add GPT instructions for generating reports

## Testing
- `npm install`
- `node index.js & sleep 3; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_684f30c87f148328a16ff9479e110a65