### PR TITLE
Implementa caché local y mejora manejo de errores

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,6 +1,8 @@
 // Configuración centralizada de constantes.
 // Cualquier cambio en las rutas o base de la API debe realizarse aquí.
 
+const path = require('path');
+
 /** Rutas equivalentes para consultar las tareas */
 const API_TAREAS_ENDPOINTS = ['/api_tareas', '/api_tareas.php'];
 
@@ -10,8 +12,12 @@ const CLICKUP_API_BASE = 'https://api.clickup.com/api/v2';
 /** Milisegundos que conforman un día (24 h) */
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/** Directorio donde se guarda la cache de tareas */
+const CACHE_DIR = path.join(__dirname, 'cache');
+
 module.exports = {
   API_TAREAS_ENDPOINTS,
   CLICKUP_API_BASE,
   DAY_MS,
+  CACHE_DIR,
 };

--- a/utils/clickup.js
+++ b/utils/clickup.js
@@ -1,5 +1,7 @@
+const fs = require('fs').promises;
+const path = require('path');
 const fetch = require('node-fetch');
-const { CLICKUP_API_BASE } = require('../config');
+const { CLICKUP_API_BASE, CACHE_DIR } = require('../config');
 
 /**
  * Realiza una solicitud a la API de ClickUp.
@@ -28,13 +30,54 @@ async function callClickUp(endpoint, token, params = {}) {
 }
 
 /**
+ * Lee la caché local de tareas.
+ * @param {string} teamId - Identificador del equipo.
+ * @returns {Promise<object|null>} Datos del archivo o null si no existe.
+ */
+async function leerCache(teamId) {
+  try {
+    const file = path.join(CACHE_DIR, `tareas_${teamId}.json`);
+    const contenido = await fs.readFile(file, 'utf8');
+    return JSON.parse(contenido);
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * Guarda datos de tareas en la caché local.
+ * @param {string} teamId - Identificador del equipo.
+ * @param {object} datos - Datos de tareas a almacenar.
+ */
+async function guardarCache(teamId, datos) {
+  try {
+    await fs.mkdir(CACHE_DIR, { recursive: true });
+    const file = path.join(CACHE_DIR, `tareas_${teamId}.json`);
+    await fs.writeFile(file, JSON.stringify(datos, null, 2));
+  } catch (err) {
+    // Silencia errores de escritura para no afectar la respuesta principal
+    console.error('Error guardando caché:', err.message);
+  }
+}
+
+/**
  * Obtiene las tareas de un equipo en ClickUp.
  * @param {string} teamId - ID del equipo.
  * @param {string} token - Token de autenticación.
  * @returns {Promise<object>} Tareas obtenidas.
  */
-function obtenerTareas(teamId, token, params = {}) {
-  return callClickUp(`/team/${teamId}/task`, token, params);
+async function obtenerTareas(teamId, token, params = {}) {
+  try {
+    const datos = await callClickUp(`/team/${teamId}/task`, token, params);
+    await guardarCache(teamId, datos);
+    return datos;
+  } catch (err) {
+    const cache = await leerCache(teamId);
+    if (cache) {
+      return cache;
+    }
+    throw err;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- añade ruta de caché en `config.js`
- agrega funciones de lectura y escritura de caché en `utils/clickup.js`
- maneja errores consultando la caché cuando la API externa falla

## Testing
- `npm test` *(falla: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f4569015c832898038dc28ba6de52