### PR TITLE
Actualiza API para usar space_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ web: node index.js
 
 | Método | Ruta                                              | Descripción                                                                     |
 | ------ | ------------------------------------------------- | ------------------------------------------------------------------------------- |
-| GET    | `/api_tareas?team_id=9015702015`              | Devuelve el JSON cacheado con tareas.                                           |
-| GET    | `/actualizar_cache?team_id=9015702015&dias=7` | Llama a ClickUp, filtra últimas *N* días, guarda en `cache/tareas_{team}.json`. |
+| GET    | `/api_tareas?space_id=9015702015`              | Devuelve el JSON cacheado con tareas.                                           |
+| GET    | `/actualizar_cache?space_id=9015702015&dias=7` | Llama a ClickUp, filtra últimas *N* días, guarda en `cache/tareas_{space}.json`. |
 
 ### Ejemplo de respuesta `/api_tareas.php`
 
@@ -114,7 +114,7 @@ Incluye parámetros, ejemplos y códigos 200 / 400 / 500.
 2. En **ChatGPT → “Create a GPT”**:
 
    * Tools → “Add your API” → pega `https://reportes.pigmea.click/openapi.json`.
-   * Añade instrucciones (ej.: “Cuando el usuario pida *tareas recientes*, llama a `obtenerTareas` con `team_id`=`9015702015`”).
+   * Añade instrucciones (ej.: “Cuando el usuario pida *tareas recientes*, llama a `obtenerTareas` con `space_id`=`9015702015`”).
 3. Prueba diálogos:
 
    * *“Actualiza la caché de Pigmea y dame las tareas de los últimos 3 días.”* → GPT invoca `actualizarCache`, luego `obtenerTareas`.
@@ -141,10 +141,10 @@ Incluye parámetros, ejemplos y códigos 200 / 400 / 500.
 ```php
 <?php
 header("Content-Type: application/json");
-$team = $_GET['team_id'] ?? null;
-if (!$team) { echo json_encode(["error"=>"team_id requerido"]); exit; }
+$space = $_GET['space_id'] ?? null;
+if (!$space) { echo json_encode(["error"=>"space_id requerido"]); exit; }
 
-$cache = __DIR__ . "/cache/tareas_{$team}.json";
+$cache = __DIR__ . "/cache/tareas_{$space}.json";
 if (!file_exists($cache)) { echo json_encode(["error"=>"Cache no encontrado"]); exit; }
 
 echo file_get_contents($cache);
@@ -155,17 +155,17 @@ echo file_get_contents($cache);
 ```php
 <?php
 header("Content-Type: application/json");
-$team = $_GET['team_id'] ?? null;
+$space = $_GET['space_id'] ?? null;
 $dias = intval($_GET['dias'] ?? 7);
 $token = getenv("CLICKUP_TOKEN");
-if (!$team || !$token) { echo json_encode(["error"=>"team_id o token faltante"]); exit; }
+if (!$space || !$token) { echo json_encode(["error"=>"space_id o token faltante"]); exit; }
 
 $desde = time() - $dias*86400;
-$url = "https://api.clickup.com/api/v2/team/$team/task?archived=false&date_updated_gt=$desde";
+$url = "https://api.clickup.com/api/v2/space/$space/task?archived=false&date_updated_gt=$desde";
 $opts = [ "http"=>["header"=>"Authorization: $token\r\n"] ];
 $json = file_get_contents($url, false, stream_context_create($opts));
 
-file_put_contents(__DIR__."/cache/tareas_{$team}.json", $json);
+file_put_contents(__DIR__."/cache/tareas_{$space}.json", $json);
 echo json_encode(["success"=>true,"message"=>"Cache actualizado"]);
 ```
 
@@ -182,8 +182,8 @@ web: heroku-php-apache2 .
 | Verificación     | Comando / URL                                                                  | Resultado esperado     |
 | ---------------- | ------------------------------------------------------------------------------ | ---------------------- |
 | Heroku responde  | `curl -I https://reportes.pigmea.click/`                                       | `HTTP/2 200`           |
-| Endpoint JSON    | `https://reportes.pigmea.click/api_tareas.php?team_id=9015702015`              | Lista de tareas        |
-| Actualizar caché | `https://reportes.pigmea.click/actualizar_cache.php?team_id=9015702015&dias=3` | `{"success":true,...}` |
+| Endpoint JSON    | `https://reportes.pigmea.click/api_tareas.php?space_id=9015702015`              | Lista de tareas        |
+| Actualizar caché | `https://reportes.pigmea.click/actualizar_cache.php?space_id=9015702015&dias=3` | `{"success":true,...}` |
 | OpenAPI          | `https://reportes.pigmea.click/openapi.json`                                   | Archivo JSON           |
 
 ---

--- a/openapi.json
+++ b/openapi.json
@@ -15,9 +15,9 @@
         "summary": "Devuelve tareas del espacio indicado",
         "parameters": [
           {
-            "name": "team_id",
+            "name": "space_id",
             "in": "query",
-            "description": "Identificador del espacio o equipo",
+            "description": "Identificador del espacio en ClickUp",
             "required": true,
             "schema": { "type": "string" }
           },
@@ -51,9 +51,9 @@
         "summary": "Refresca la caché local consultando ClickUp",
         "parameters": [
           {
-            "name": "team_id",
+            "name": "space_id",
             "in": "query",
-            "description": "Identificador del espacio o equipo",
+            "description": "Identificador del espacio en ClickUp",
             "required": true,
             "schema": { "type": "string" }
           },

--- a/utils/clickup.js
+++ b/utils/clickup.js
@@ -7,7 +7,8 @@ const { CLICKUP_API_BASE, CACHE_DIR } = require('../config');
  * Realiza una solicitud a la API de ClickUp.
  * @param {string} endpoint - Endpoint a consultar.
  * @param {string} token - Token de autenticación para la API.
- * @returns {Promise<object>} Respuesta JSON de la API.
+ * Devuelve el JSON recibido.
+ * Lanza un error con la propiedad `status` cuando la respuesta no es exitosa.
  */
 async function callClickUp(endpoint, token, params = {}) {
   const url = new URL(`${CLICKUP_API_BASE}${endpoint}`);
@@ -21,22 +22,25 @@ async function callClickUp(endpoint, token, params = {}) {
       headers: { Authorization: token },
     });
     if (!resp.ok) {
-      throw new Error(`Error ${resp.status}`);
+      const error = new Error(`Error ${resp.status}`);
+      error.status = resp.status;
+      throw error;
     }
     return await resp.json();
   } catch (err) {
-    throw new Error(`Fallo al conectar con ClickUp: ${err.message}`);
+    // Propaga el mismo error para manejo posterior en las rutas
+    throw err;
   }
 }
 
 /**
  * Lee la caché local de tareas.
- * @param {string} teamId - Identificador del equipo.
+ * @param {string} spaceId - Identificador del espacio.
  * @returns {Promise<object|null>} Datos del archivo o null si no existe.
  */
-async function leerCache(teamId) {
+async function leerCache(spaceId) {
   try {
-    const file = path.join(CACHE_DIR, `tareas_${teamId}.json`);
+    const file = path.join(CACHE_DIR, `tareas_${spaceId}.json`);
     const contenido = await fs.readFile(file, 'utf8');
     return JSON.parse(contenido);
   } catch (err) {
@@ -46,13 +50,13 @@ async function leerCache(teamId) {
 
 /**
  * Guarda datos de tareas en la caché local.
- * @param {string} teamId - Identificador del equipo.
+ * @param {string} spaceId - Identificador del espacio.
  * @param {object} datos - Datos de tareas a almacenar.
  */
-async function guardarCache(teamId, datos) {
+async function guardarCache(spaceId, datos) {
   try {
     await fs.mkdir(CACHE_DIR, { recursive: true });
-    const file = path.join(CACHE_DIR, `tareas_${teamId}.json`);
+    const file = path.join(CACHE_DIR, `tareas_${spaceId}.json`);
     await fs.writeFile(file, JSON.stringify(datos, null, 2));
   } catch (err) {
     // Silencia errores de escritura para no afectar la respuesta principal
@@ -61,18 +65,18 @@ async function guardarCache(teamId, datos) {
 }
 
 /**
- * Obtiene las tareas de un equipo en ClickUp.
- * @param {string} teamId - ID del equipo.
+ * Obtiene las tareas de un espacio en ClickUp.
+ * @param {string} spaceId - ID del espacio.
  * @param {string} token - Token de autenticación.
  * @returns {Promise<object>} Tareas obtenidas.
  */
-async function obtenerTareas(teamId, token, params = {}) {
+async function obtenerTareas(spaceId, token, params = {}) {
   try {
-    const datos = await callClickUp(`/team/${teamId}/task`, token, params);
-    await guardarCache(teamId, datos);
+    const datos = await callClickUp(`/space/${spaceId}/task`, token, params);
+    await guardarCache(spaceId, datos);
     return datos;
   } catch (err) {
-    const cache = await leerCache(teamId);
+    const cache = await leerCache(spaceId);
     if (cache) {
       return cache;
     }


### PR DESCRIPTION
## Summary
- usa `space_id` en vez de `team_id` para consultar tareas
- maneja errores 404 de ClickUp
- actualiza la documentación de la API y el ejemplo de PHP

## Testing
- `npm install`
- `node index.js` *(se inició sin errores)*
- `npm test` *(falló: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_684f4ce65250832885d920ef3f9b824f