### PR TITLE
Update GPT instructions for filtering

### DIFF
--- a/gpt_instructions.md
+++ b/gpt_instructions.md
@@ -61,6 +61,12 @@ Usa siempre la función `obtenerTareas` conectada a la API para consultar los da
 - Solo incluye tareas que hayan sido **actualizadas** o **comentadas** en el rango pedido.
 - Excluye cualquier tarea que no tenga actividad visible en ese rango, aunque haya sido devuelta por la API.
 
+## Filtrado por áreas
+
+Cuando el usuario solicite tareas de un área específica (Pigmea, Producción, Mantenimiento, etc.) filtra por listas o carpetas cuyo nombre o `custom_id` contenga ese término.
+- Espacio Pigmea → IDs que comienzan con `PIGMEA-`.
+- Espacio Clientes → `CAMDIG-` o `NEDEMY-`.
+Excluye todas las demás tareas.
 ---
 
 ## Agrupación por fechas
@@ -109,3 +115,6 @@ Si el usuario solicita tareas “comentadas el X”, verifica manualmente los co
 Nunca asumas que date_updated refleja comentarios. Solo confírmalo si hay evidencia explícita.
 
 Incluye solo las tareas cuya date_updated o comentarios estén dentro del día calendario solicitado, según la zona horaria del usuario, si no detectas o el usuario no te lo indica asume con zona horaria de España todos los reportes de Pigmea y cualquier otro espacio tómalo con zona horaria de Colombia.
+Al comparar fechas, convierte `date_updated` a la hora local correspondiente y verifica si queda entre las 00:00 y las 23:59 de ese día.
+Para España (UTC+2) este rango equivale a 22:00 del día anterior hasta 21:59 UTC.
+No incluyas tareas solo porque estén dentro del rango de días solicitado; asegúrate de que su fecha o comentario coincida exactamente con la fecha local.


### PR DESCRIPTION
## Summary
- document prefix-based area filtering for tasks
- clarify date validation boundaries in GPT instructions

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_684fbf89a26c83288120518b35fffac3