### PR TITLE
Improve ClickUp filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ web: node index.js
 
 | Método | Ruta                                              | Descripción                                                                     |
 | ------ | ------------------------------------------------- | ------------------------------------------------------------------------------- |
-| GET    | `/api_tareas?team_id=9015702015`              | Devuelve el JSON cacheado con tareas.                                           |
-| GET    | `/actualizar_cache?team_id=9015702015&dias=7` | Llama a ClickUp, filtra últimas *N* días, guarda en `cache/tareas_{team}.json`. |
+| GET    | `/api_tareas?team_id=9015702015`              | Devuelve el JSON cacheado con tareas. Permite filtrar con `prefix`, `fecha` y `timezone`. |
+| GET    | `/actualizar_cache?team_id=9015702015&dias=7` | Llama a ClickUp, filtra últimas *N* días, guarda en `cache/tareas_{team}.json`. Acepta también `prefix`, `fecha` y `timezone`. |
 
 ### Ejemplo de respuesta `/api_tareas.php`
 

--- a/openapi.json
+++ b/openapi.json
@@ -41,6 +41,27 @@
             "description": "Número máximo de tareas a solicitar",
             "required": false,
             "schema": { "type": "integer", "minimum": 1 }
+          },
+          {
+            "name": "prefix",
+            "in": "query",
+            "description": "Prefijo del custom_id para filtrar tareas (ej. PIGMEA-)",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "fecha",
+            "in": "query",
+            "description": "Fecha local YYYY-MM-DD para filtrar por date_updated",
+            "required": false,
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "description": "Zona horaria en horas respecto a UTC (ej. 2, -5)",
+            "required": false,
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {
@@ -84,6 +105,27 @@
             "description": "Número máximo de tareas a solicitar",
             "required": false,
             "schema": { "type": "integer", "minimum": 1 }
+          },
+          {
+            "name": "prefix",
+            "in": "query",
+            "description": "Prefijo del custom_id para filtrar tareas (ej. PIGMEA-)",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "fecha",
+            "in": "query",
+            "description": "Fecha local YYYY-MM-DD para filtrar por date_updated",
+            "required": false,
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "description": "Zona horaria en horas respecto a UTC (ej. 2, -5)",
+            "required": false,
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {

--- a/routes/tareas.js
+++ b/routes/tareas.js
@@ -23,7 +23,15 @@ function obtenerToken(req) {
  * @returns {{teamId: string, token: string, params: Record<string, any>}|null}
  */
 function obtenerParametros(req) {
-  const { team_id: teamId, token: _unused, dias, ...rest } = req.query;
+  const {
+    team_id: teamId,
+    token: _unused,
+    dias,
+    prefix,
+    fecha,
+    timezone,
+    ...rest
+  } = req.query;
   const token = obtenerToken(req);
   if (!teamId || !token) {
     return null;
@@ -35,7 +43,8 @@ function obtenerParametros(req) {
       params.date_updated_gt = Date.now() - diasNum * DAY_MS;
     }
   }
-  return { teamId, token, params };
+  const filtro = { prefix, fecha, timezone };
+  return { teamId, token, params, filtro };
 }
 
 /**
@@ -49,10 +58,10 @@ async function manejarApiTareas(req, res) {
     return res.status(400).json({ error: 'Par\xC3\xA1metro team_id o token faltante' });
   }
 
-  const { teamId, token, params } = data;
+  const { teamId, token, params, filtro } = data;
 
   try {
-    const datos = await obtenerTareas(teamId, token, params);
+    const datos = await obtenerTareas(teamId, token, params, filtro);
     res.json(datos);
   } catch (err) {
     res.status(500).json({
@@ -71,9 +80,9 @@ async function manejarActualizarCache(req, res) {
     return res.status(400).json({ error: 'Par\xC3\xA1metro team_id o token faltante' });
   }
 
-  const { teamId, token, params } = data;
+  const { teamId, token, params, filtro } = data;
   try {
-    await obtenerTareas(teamId, token, params);
+    await obtenerTareas(teamId, token, params, filtro);
     res.json({ success: true, message: 'Cache actualizada' });
   } catch (err) {
     res.status(500).json({


### PR DESCRIPTION
## Summary
- filter tasks by prefix and date with timezone
- expose new query params in API routes and OpenAPI spec
- document additional filters in README

## Testing
- `node -c utils/clickup.js && node -c routes/tareas.js`
- `npm install`
- `npm start` *(fails: request to ClickUp fails due to missing credentials)*

------
https://chatgpt.com/codex/tasks/task_e_684fc65ab9b48328aedc430e43d89e95