### PR TITLE
Add endpoint for folder tasks

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,6 +9,9 @@ const API_TAREAS_ENDPOINTS = ['/api_tareas', '/api_tareas.php'];
 /** Rutas para actualizar manualmente la caché */
 const ACTUALIZAR_CACHE_ENDPOINTS = ['/actualizar_cache', '/actualizar_cache.php'];
 
+/** Rutas para obtener tareas de todas las listas en una carpeta */
+const CARPETA_TAREAS_ENDPOINTS = ['/tareas_carpeta', '/tareas_carpeta.php'];
+
 /** URL base para todas las llamadas a la API de ClickUp */
 const CLICKUP_API_BASE = 'https://api.clickup.com/api/v2';
 
@@ -49,6 +52,7 @@ const COMMENTS_PAGE_SIZE = 20;
 module.exports = {
   API_TAREAS_ENDPOINTS,
   ACTUALIZAR_CACHE_ENDPOINTS,
+  CARPETA_TAREAS_ENDPOINTS,
   CLICKUP_API_BASE,
   DAY_MS,
   CACHE_DIR,

--- a/openapi.json
+++ b/openapi.json
@@ -173,6 +173,82 @@
         "responses": {
           "200": { "description": "Cache actualizada" },
           "400": { "description": "Parámetros faltantes" },
+        "500": { "description": "Fallo interno" }
+        }
+      }
+    },
+    "/tareas_carpeta.php": {
+      "get": {
+        "operationId": "obtenerTareasCarpeta",
+        "summary": "Devuelve tareas de todas las listas de una carpeta",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "query",
+            "description": "Identificador de la carpeta",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "description": "Token opcional si no está definido en el servidor",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "dias",
+            "in": "query",
+            "description": "Número de días a consultar en ClickUp",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 1 }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "Número máximo de tareas a solicitar",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 1 }
+          },
+          {
+            "name": "prefix",
+            "in": "query",
+            "description": "Prefijo del custom_id para filtrar tareas (ej. PIGMEA-)",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "fecha_inicio",
+            "in": "query",
+            "description": "Fecha local inicial YYYY-MM-DD para filtrar",
+            "required": false,
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "fecha_fin",
+            "in": "query",
+            "description": "Fecha local final YYYY-MM-DD para filtrar",
+            "required": false,
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "fecha",
+            "in": "query",
+            "description": "Fecha local YYYY-MM-DD para filtrar por date_updated",
+            "required": false,
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "description": "Zona horaria en horas respecto a UTC (ej. 2, -5)",
+            "required": false,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Lista de tareas obtenidas" },
+          "400": { "description": "Parámetros faltantes" },
           "500": { "description": "Fallo interno" }
         }
       }

--- a/routes/tareas.js
+++ b/routes/tareas.js
@@ -1,8 +1,9 @@
 const express = require('express');
-const { obtenerTareas } = require('../utils/clickup');
+const { obtenerTareas, obtenerTareasCarpeta } = require('../utils/clickup');
 const {
   API_TAREAS_ENDPOINTS,
   ACTUALIZAR_CACHE_ENDPOINTS,
+  CARPETA_TAREAS_ENDPOINTS,
   DAY_MS,
 } = require('../config');
 
@@ -50,6 +51,38 @@ function obtenerParametros(req) {
 }
 
 /**
+ * Construye los parámetros para consultas por carpeta.
+ * @param {import('express').Request} req
+ * @returns {{folderId: string, token: string, params: Record<string, any>}|null}
+ */
+function obtenerParametrosCarpeta(req) {
+  const {
+    folder_id: folderId,
+    token: _unused,
+    dias,
+    prefix,
+    fecha,
+    fecha_inicio,
+    fecha_fin,
+    timezone,
+    ...rest
+  } = req.query;
+  const token = obtenerToken(req);
+  if (!folderId || !token) {
+    return null;
+  }
+  const params = { ...rest };
+  if (dias) {
+    const diasNum = Number(dias);
+    if (!Number.isNaN(diasNum) && diasNum > 0) {
+      params.date_updated_gt = Date.now() - diasNum * DAY_MS;
+    }
+  }
+  const filtro = { prefix, fecha, fecha_inicio, fecha_fin, timezone };
+  return { folderId, token, params, filtro };
+}
+
+/**
  * Maneja la obtenci\xC3\xB3n de tareas desde ClickUp.
  * Requiere el par\xC3\xA1metro `team_id` y un token v\xC3\xA1lido en la configuraci\xC3\xB3n
  * o en la consulta.
@@ -94,7 +127,29 @@ async function manejarActualizarCache(req, res) {
   }
 }
 
+/**
+ * Devuelve las tareas de todas las listas dentro de una carpeta.
+ */
+async function manejarTareasCarpeta(req, res) {
+  const data = obtenerParametrosCarpeta(req);
+  if (!data) {
+    return res.status(400).json({ error: 'Par\xC3\xA1metro folder_id o token faltante' });
+  }
+
+  const { folderId, token, params, filtro } = data;
+  try {
+    const datos = await obtenerTareasCarpeta(folderId, token, params, filtro);
+    res.json({ folder_id: folderId, listas: datos });
+  } catch (err) {
+    res.status(500).json({
+      error: 'Error al consultar ClickUp',
+      details: err.message,
+    });
+  }
+}
+
 router.get(API_TAREAS_ENDPOINTS, manejarApiTareas);
 router.get(ACTUALIZAR_CACHE_ENDPOINTS, manejarActualizarCache);
+router.get(CARPETA_TAREAS_ENDPOINTS, manejarTareasCarpeta);
 
 module.exports = router;

--- a/utils/clickup.js
+++ b/utils/clickup.js
@@ -199,6 +199,34 @@ async function obtenerTareas(teamId, token, params = {}, filtro = {}) {
   }
 }
 
+/**
+ * Devuelve las listas dentro de una carpeta.
+ */
+async function obtenerListasCarpeta(folderId, token) {
+  const datos = await callClickUp(`/folder/${folderId}/list`, token);
+  return Array.isArray(datos.lists) ? datos.lists : [];
+}
+
+/**
+ * Obtiene las tareas de todas las listas en una carpeta.
+ */
+async function obtenerTareasCarpeta(folderId, token, params = {}, filtro = {}) {
+  const listas = await obtenerListasCarpeta(folderId, token);
+  const resultados = [];
+  for (const lista of listas) {
+    const datos = await obtenerTareas(
+      `folder_${folderId}`,
+      token,
+      { ...params, list_id: lista.id },
+      filtro,
+    );
+    resultados.push({ lista, tasks: datos.tasks });
+  }
+  return resultados;
+}
+
 module.exports = {
   obtenerTareas,
+  obtenerListasCarpeta,
+  obtenerTareasCarpeta,
 };


### PR DESCRIPTION
## Summary
- add configuration for folder tasks endpoints
- expose new `/tareas_carpeta.php` route to return tasks from all lists in a folder
- support fetching lists and tasks per folder in `clickup` utility
- document new route in OpenAPI spec

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862b08825c8832895ce14652d06d446